### PR TITLE
Change the dataWindow property to dateWindow

### DIFF
--- a/src/components/Dygraph/options.js
+++ b/src/components/Dygraph/options.js
@@ -23,7 +23,7 @@ const options = {
     connectSeparatedPoints: {type: p.boolean},
     customBars: {type: p.boolean},
     dataHandler: true,
-    dataWindow: true,
+    dateWindow: true,
     delimiter: {type: p.string},
     digitsAfterDecimal: {type: p.number},
     displayAnnotations: {type: p.boolean},


### PR DESCRIPTION
The Dygraphs option is called dateWindow, not dataWindow. This fixes the inability to change the x range using properties.

http://dygraphs.com/options.html#dateWindow